### PR TITLE
Fix activity lifecycle

### DIFF
--- a/app/src/main/java/org/mozilla/search/Constants.java
+++ b/app/src/main/java/org/mozilla/search/Constants.java
@@ -15,9 +15,10 @@ package org.mozilla.search;
  * https://github.com/ericedens/FirefoxSearch/issues/3
  */
 public class Constants {
-    public static final String SEARCH_FRAGMENT = "org.mozilla.search.SEARCH_FRAGMENT";
+
     public static final String PRESEARCH_FRAGMENT = "org.mozilla.search.PRESEARCH_FRAGMENT";
     public static final String POSTSEARCH_FRAGMENT = "org.mozilla.search.POSTSEARCH_FRAGMENT";
+    public static final String SEARCH_FRAGMENT = "org.mozilla.search.SEARCH_FRAGMENT";
 
     public static final String AUTOCOMPLETE_ROW_LIMIT = "5";
 }

--- a/app/src/main/java/org/mozilla/search/Constants.java
+++ b/app/src/main/java/org/mozilla/search/Constants.java
@@ -15,9 +15,9 @@ package org.mozilla.search;
  * https://github.com/ericedens/FirefoxSearch/issues/3
  */
 public class Constants {
-    public static final String AUTO_COMPLETE_FRAGMENT = "org.mozilla.search.AUTO_COMPLETE_FRAGMENT";
-    public static final String CARD_STREAM_FRAGMENT = "org.mozilla.search.CARD_STREAM_FRAGMENT";
-    public static final String GECKO_VIEW_FRAGMENT = "org.mozilla.search.GECKO_VIEW_FRAGMENT";
+    public static final String SEARCH_FRAGMENT = "org.mozilla.search.SEARCH_FRAGMENT";
+    public static final String PRESEARCH_FRAGMENT = "org.mozilla.search.PRESEARCH_FRAGMENT";
+    public static final String POSTSEARCH_FRAGMENT = "org.mozilla.search.POSTSEARCH_FRAGMENT";
 
     public static final String AUTOCOMPLETE_ROW_LIMIT = "5";
 }

--- a/app/src/main/java/org/mozilla/search/MainActivity.java
+++ b/app/src/main/java/org/mozilla/search/MainActivity.java
@@ -11,8 +11,8 @@ import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
 
 import org.mozilla.search.autocomplete.AcceptsSearchQuery;
-import org.mozilla.search.autocomplete.AutoCompleteFragment;
-import org.mozilla.search.stream.CardStreamFragment;
+import org.mozilla.search.autocomplete.SearchFragment;
+import org.mozilla.search.stream.PreSearchFragment;
 
 
 /**
@@ -23,81 +23,86 @@ import org.mozilla.search.stream.CardStreamFragment;
  * now, the only message passing occurs when a user wants to submit a search query. That
  * passes through the onSearch method here.
  */
-public class MainActivity extends FragmentActivity implements AcceptsSearchQuery,
-        FragmentManager.OnBackStackChangedListener {
+public class MainActivity extends FragmentActivity implements AcceptsSearchQuery {
 
-    private DetailActivity detailActivity;
+    private PreSearchFragment preSearchFragment;
+    private PostSearchFragment postSearchFragment;
+    private SearchFragment searchFragment;
+    private FragmentManager fragmentManager;
 
+    /**
+     * Initialize all of the fragments, and add them to the fragment tree.
+     */
     @Override
     protected void onCreate(Bundle stateBundle) {
         super.onCreate(stateBundle);
-
-        // Sets the content view for the Activity
         setContentView(R.layout.search_activity_main);
 
-        // Gets an instance of the support library FragmentManager
-        FragmentManager localFragmentManager = getSupportFragmentManager();
+        boolean geckoNeedsToBeHidden = true;
 
-        // If the incoming state of the Activity is null, sets the initial view to be thumbnails
-        if (null == stateBundle) {
-
-            // Starts a Fragment transaction to track the stack
-            FragmentTransaction localFragmentTransaction = localFragmentManager.beginTransaction();
-
-            localFragmentTransaction.add(R.id.header_fragments, new AutoCompleteFragment(),
-                    Constants.AUTO_COMPLETE_FRAGMENT);
-
-            localFragmentTransaction.add(R.id.presearch_fragments, new CardStreamFragment(),
-                    Constants.CARD_STREAM_FRAGMENT);
-
-            // Commits this transaction to display the Fragment
-            localFragmentTransaction.commit();
-
-            // The incoming state of the Activity isn't null.
-        }
-    }
-
-    @Override
-    protected void onStart() {
-        super.onStart();
-
-
-        if (null == detailActivity) {
-            detailActivity = new DetailActivity();
+        if (fragmentManager == null) {
+            fragmentManager = getSupportFragmentManager();
         }
 
-        if (null == getSupportFragmentManager().findFragmentByTag(Constants.GECKO_VIEW_FRAGMENT)) {
-            FragmentTransaction txn = getSupportFragmentManager().beginTransaction();
-            txn.add(R.id.gecko_fragments, detailActivity, Constants.GECKO_VIEW_FRAGMENT);
-            txn.hide(detailActivity);
+        final FragmentTransaction txn = fragmentManager.beginTransaction();
 
+        preSearchFragment = (PreSearchFragment) fragmentManager.findFragmentByTag(Constants.PRESEARCH_FRAGMENT);
+        postSearchFragment = (PostSearchFragment) fragmentManager.findFragmentByTag(Constants.POSTSEARCH_FRAGMENT);
+        searchFragment = (SearchFragment) fragmentManager.findFragmentByTag(Constants.SEARCH_FRAGMENT);
+
+
+        if (preSearchFragment == null) {
+            preSearchFragment = new PreSearchFragment();
+            txn.add(R.id.presearch_fragments, preSearchFragment, Constants.PRESEARCH_FRAGMENT);
+        }
+
+        if (postSearchFragment == null) {
+            postSearchFragment = new PostSearchFragment();
+            txn.add(R.id.gecko_fragments, postSearchFragment, Constants.POSTSEARCH_FRAGMENT);
+            txn.hide(postSearchFragment);
+            geckoNeedsToBeHidden = false;
+        }
+
+        if (searchFragment == null) {
+            searchFragment = new SearchFragment();
+            txn.add(R.id.header_fragments, searchFragment, Constants.SEARCH_FRAGMENT);
+        }
+
+        // Only commit the transaction if there are pending operations.
+        if (!txn.isEmpty()) {
             txn.commit();
+            if (geckoNeedsToBeHidden) {
+                fragmentManager.executePendingTransactions();
+            }
+        }
+
+        if (geckoNeedsToBeHidden) {
+            showPreSearch();
         }
     }
 
     @Override
     public void onSearch(String s) {
-        FragmentManager localFragmentManager = getSupportFragmentManager();
-        FragmentTransaction localFragmentTransaction = localFragmentManager.beginTransaction();
-
-        localFragmentTransaction
-                .hide(localFragmentManager.findFragmentByTag(Constants.CARD_STREAM_FRAGMENT))
-                .addToBackStack(null);
-
-        localFragmentTransaction
-                .show(localFragmentManager.findFragmentByTag(Constants.GECKO_VIEW_FRAGMENT))
-                .addToBackStack(null);
-
-        localFragmentTransaction.commit();
-
-
-        ((DetailActivity) getSupportFragmentManager()
-                .findFragmentByTag(Constants.GECKO_VIEW_FRAGMENT))
-                .setUrl("https://search.yahoo.com/search?p=" + Uri.encode(s));
+        // TODO: If the search started from the geckoview, then this call would
+        // not only be unnecessary, but it would also put another fragment
+        // state on the backstack. Can we detect the state of the backstack?
+        // If not, should we maintain some state fields in this class?
+        showPostSearch();
+        postSearchFragment.setUrl("https://search.yahoo.com/search?p=" + Uri.encode(s));
     }
 
-    @Override
-    public void onBackStackChanged() {
-
+    private void showPreSearch() {
+        final FragmentTransaction txn = fragmentManager.beginTransaction();
+        txn.show(preSearchFragment).addToBackStack(null);
+        txn.hide(postSearchFragment).addToBackStack(null);
+        txn.commit();
     }
+
+    private void showPostSearch() {
+        final FragmentTransaction txn = fragmentManager.beginTransaction();
+        txn.show(postSearchFragment).addToBackStack(null);
+        txn.hide(preSearchFragment).addToBackStack(null);
+        txn.commit();
+    }
+
 }

--- a/app/src/main/java/org/mozilla/search/PostSearchFragment.java
+++ b/app/src/main/java/org/mozilla/search/PostSearchFragment.java
@@ -18,9 +18,9 @@ import org.mozilla.gecko.GeckoViewChrome;
 import org.mozilla.gecko.GeckoViewContent;
 import org.mozilla.gecko.PrefsHelper;
 
-public class DetailActivity extends Fragment {
+public class PostSearchFragment extends Fragment {
 
-    private static final String LOGTAG = "DetailActivity";
+    private static final String LOGTAG = "PostSearchFragment";
     private GeckoView geckoView;
 
 

--- a/app/src/main/java/org/mozilla/search/autocomplete/SearchFragment.java
+++ b/app/src/main/java/org/mozilla/search/autocomplete/SearchFragment.java
@@ -33,7 +33,7 @@ import org.mozilla.search.R;
  * TODO: Add clear button to search input
  * TODO: Add more search providers (other than the dictionary)
  */
-public class AutoCompleteFragment extends Fragment implements AdapterView.OnItemClickListener,
+public class SearchFragment extends Fragment implements AdapterView.OnItemClickListener,
         TextView.OnEditorActionListener, AcceptsJumpTaps {
 
     private View mainView;
@@ -50,7 +50,7 @@ public class AutoCompleteFragment extends Fragment implements AdapterView.OnItem
         RUNNING   // The user is in search mode.
     }
 
-    public AutoCompleteFragment() {
+    public SearchFragment() {
         // Required empty public constructor
     }
 

--- a/app/src/main/java/org/mozilla/search/stream/PreSearchFragment.java
+++ b/app/src/main/java/org/mozilla/search/stream/PreSearchFragment.java
@@ -17,7 +17,7 @@ import org.mozilla.search.R;
  * we only use this during pre-search, but we could also use it
  * during post-search at some point.
  */
-public class CardStreamFragment extends ListFragment {
+public class PreSearchFragment extends ListFragment {
 
     private ArrayAdapter<PreloadAgent.TmpItem> adapter;
 
@@ -25,7 +25,7 @@ public class CardStreamFragment extends ListFragment {
      * Mandatory empty constructor for the fragment manager to instantiate the
      * fragment (e.g. upon screen orientation changes).
      */
-    public CardStreamFragment() {
+    public PreSearchFragment() {
     }
 
     @Override

--- a/app/src/main/java/org/mozilla/search/stream/PreloadAgent.java
+++ b/app/src/main/java/org/mozilla/search/stream/PreloadAgent.java
@@ -12,7 +12,7 @@ import java.util.Map;
 /**
  * A temporary agent for loading cards into the pre-load card stream.
  * <p/>
- * When we have more agents, we'll want to put an agent manager between the CardStreamFragment
+ * When we have more agents, we'll want to put an agent manager between the PreSearchFragment
  * and the set of all agents. See autocomplete.AutoCompleteFragmentManager.
  */
 class PreloadAgent {

--- a/app/src/main/java/org/mozilla/search/tests/MainActivityTest.java
+++ b/app/src/main/java/org/mozilla/search/tests/MainActivityTest.java
@@ -1,0 +1,102 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.search.tests;
+
+import android.test.ActivityInstrumentationTestCase2;
+
+import org.mozilla.search.Constants;
+import org.mozilla.search.MainActivity;
+import org.mozilla.search.PostSearchFragment;
+import org.mozilla.search.autocomplete.SearchFragment;
+import org.mozilla.search.stream.PreSearchFragment;
+
+public class MainActivityTest extends ActivityInstrumentationTestCase2<MainActivity> {
+
+    public MainActivityTest() {
+        super(MainActivity.class);
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+    }
+
+    public void testPreConditions() {
+        assertPreSearchVisible();
+    }
+
+    public void testSearch() {
+        getActivity().runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                getActivity().onSearch("cable");
+                getActivity().getSupportFragmentManager().executePendingTransactions();
+            }
+        });
+        getInstrumentation().waitForIdleSync();
+
+        assertPostSearchVisible();
+
+        getActivity().runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                getActivity().onBackPressed();
+            }
+        });
+        getInstrumentation().waitForIdleSync();
+
+        assertPreSearchVisible();
+    }
+
+    public void testDestroy() {
+        getActivity().runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                getActivity().onSearch("cable");
+                getActivity().getSupportFragmentManager().executePendingTransactions();
+            }
+        });
+        getInstrumentation().waitForIdleSync();
+        assertPostSearchVisible();
+
+        getActivity().finish();
+        getInstrumentation().waitForIdleSync();
+        setActivity(null);
+
+        // Restart the activity.
+        getActivity();
+
+        getInstrumentation().waitForIdleSync();
+
+        assertPreSearchVisible();
+    }
+
+    private PostSearchFragment getPostSearchFragment() {
+        return (PostSearchFragment) getActivity()
+                .getSupportFragmentManager().findFragmentByTag(Constants.POSTSEARCH_FRAGMENT);
+    }
+
+    private PreSearchFragment getPreSearchFragment() {
+        return (PreSearchFragment) getActivity()
+                .getSupportFragmentManager().findFragmentByTag(Constants.PRESEARCH_FRAGMENT);
+    }
+
+    private SearchFragment getSearchFragment() {
+        return (SearchFragment) getActivity()
+                .getSupportFragmentManager().findFragmentByTag(Constants.SEARCH_FRAGMENT);
+    }
+
+    private void assertPreSearchVisible() {
+        assertTrue(getPostSearchFragment().isHidden());
+        assertTrue(getPreSearchFragment().isVisible());
+        assertTrue(getSearchFragment().isVisible());
+    }
+
+    private void assertPostSearchVisible() {
+        assertTrue(getPostSearchFragment().isVisible());
+        assertTrue(getPreSearchFragment().isHidden());
+        assertTrue(getSearchFragment().isVisible());
+    }
+}

--- a/app/src/main/res/layout/search_activity_detail.xml
+++ b/app/src/main/res/layout/search_activity_detail.xml
@@ -10,7 +10,7 @@
                 android:paddingLeft="@dimen/activity_horizontal_margin"
                 android:paddingRight="@dimen/activity_horizontal_margin"
                 android:paddingTop="@dimen/activity_vertical_margin"
-                tools:context="org.mozilla.search.DetailActivity">
+                tools:context="org.mozilla.search.PostSearchFragment">
 
     <org.mozilla.gecko.GeckoView
         android:id="@+id/gecko_view"


### PR DESCRIPTION
Some renaming caused a lot of churn in this patch; the only substantive changes are:
  org/mozilla/search/MainActivity.java
  org/mozilla/search/tests/MainActivityTest.java

MainActivity:
  Before creating new fragments, or adding new fragments to the tree, explicitly check whether they've already been created.
MainActivityTest:
  Checks whether the proper fragments are visible after initial load, search, and having the activity recreated.
