### PR TITLE
Bug 1048545 - Make the widget icon launch fennec without opening, r=margaret

### DIFF
--- a/app/src/main/java/org/mozilla/search/SearchWidget.java
+++ b/app/src/main/java/org/mozilla/search/SearchWidget.java
@@ -27,6 +27,7 @@ public class SearchWidget extends AppWidgetProvider {
 
     final public static String ACTION_LAUNCH_BROWSER = "org.mozilla.widget.LAUNCH_BROWSER";
     final public static String ACTION_LAUNCH_SEARCH = "org.mozilla.widget.LAUNCH_SEARCH";
+    final public static String ACTION_LAUNCH_NEW_TAB = "org.mozilla.widget.LAUNCH_NEW_TAB";
 
     @SuppressLint("NewApi")
     @Override
@@ -62,10 +63,15 @@ public class SearchWidget extends AppWidgetProvider {
         final Intent redirect;
         Log.i(LOGTAG, "Got intent  " + intent.getAction());
         if (intent.getAction().equals(ACTION_LAUNCH_BROWSER)) {
-            redirect = buildRedirectIntent(Intent.ACTION_VIEW,
+            redirect = buildRedirectIntent(Intent.ACTION_MAIN,
                     AppConstants.ANDROID_PACKAGE_NAME,
                     AppConstants.BROWSER_INTENT_CLASS_NAME,
                     intent);
+        } else if (intent.getAction().equals(ACTION_LAUNCH_NEW_TAB)) {
+                redirect = buildRedirectIntent(Intent.ACTION_VIEW,
+                        AppConstants.ANDROID_PACKAGE_NAME,
+                        AppConstants.BROWSER_INTENT_CLASS_NAME,
+                        intent);
         } else if (intent.getAction().equals(ACTION_LAUNCH_SEARCH)) {
             redirect = buildRedirectIntent(Intent.ACTION_VIEW,
                     AppConstants.SEARCH_PACKAGE_NAME,
@@ -94,7 +100,7 @@ public class SearchWidget extends AppWidgetProvider {
         final RemoteViews views = new RemoteViews(context.getPackageName(), R.layout.search_widget);
 
         addClickIntent(context, views, R.id.search_button, ACTION_LAUNCH_SEARCH);
-        addClickIntent(context, views, R.id.new_tab_button, ACTION_LAUNCH_BROWSER);
+        addClickIntent(context, views, R.id.new_tab_button, ACTION_LAUNCH_NEW_TAB);
         // Clicking the logo also launches the browser
         addClickIntent(context, views, R.id.logo_button, ACTION_LAUNCH_BROWSER);
 

--- a/manifests/SearchAndroidManifest_activities.xml.in
+++ b/manifests/SearchAndroidManifest_activities.xml.in
@@ -33,6 +33,10 @@
                 <action android:name="org.mozilla.widget.LAUNCH_SEARCH"/>
             </intent-filter>
 
+            <intent-filter>
+                <action android:name="org.mozilla.widget.LAUNCH_NEW_TAB"/>
+            </intent-filter>
+
             <meta-data android:name="android.appwidget.provider" android:resource="@xml/search_widget_info" />
         </receiver>
 


### PR DESCRIPTION
This switches this button to use a different intent and to fire an Intent.ACTION_MAIN intent which will just show Fennec with whatever is the current selected tab.
