### PR TITLE
Bug 1030896 - Add ability to dismiss search history items on launch screen

### DIFF
--- a/app/src/main/java/org/mozilla/search/MainActivity.java
+++ b/app/src/main/java/org/mozilla/search/MainActivity.java
@@ -177,10 +177,10 @@ public class MainActivity extends FragmentActivity implements AcceptsSearchQuery
     public void onNewIntent(Intent intent) {
         // Reset the activity in the presearch state if it was launched from a new intent.
         setSearchState(SearchState.PRESEARCH);
-
-        // Also clear any existing search term and enter editing mode.
-        editText.setText("");
         setEditState(EditState.EDITING);
+
+        // Reset the query after entering edit mode to update the suggestions appropriately.
+        editText.setText("");
     }
 
     @Override

--- a/app/src/main/java/org/mozilla/search/PreSearchFragment.java
+++ b/app/src/main/java/org/mozilla/search/PreSearchFragment.java
@@ -220,12 +220,14 @@ public class PreSearchFragment extends Fragment {
             final String query = cursor.getString(cursor.getColumnIndexOrThrow(SearchHistory.QUERY));
             ((TextView) view).setText(query);
 
-            // Reset height that might have been changed in animation.
+            // Reset properties that might have been changed in animation.
             if (originalHeight != 0) {
                 final ViewGroup.LayoutParams lp = view.getLayoutParams();
                 lp.height = originalHeight;
                 view.setLayoutParams(lp);
             }
+
+            ViewHelper.setTranslationX(view, 0);
         }
 
         @Override

--- a/app/src/main/java/org/mozilla/search/stream/MockHistoryProvider.java
+++ b/app/src/main/java/org/mozilla/search/stream/MockHistoryProvider.java
@@ -38,7 +38,19 @@ public class MockHistoryProvider extends ContentProvider {
 
     @Override
     public int delete(Uri uri, String selection, String[] selectionArgs) {
-        return 1;
+        if (queries == null) {
+            queries = getFromSp();
+        }
+
+        // Assume selectionArgs[0] is the query we want to delete
+        final int index = queries.indexOf(selectionArgs[0]);
+        if (index >= 0) {
+            queries.remove(index);
+            writeToSp(queries);
+            return 1;
+        }
+
+        return 0;
     }
 
     @Override
@@ -56,7 +68,7 @@ public class MockHistoryProvider extends ContentProvider {
         if (queries.contains(query)) {
             return null;
         }
-        while (queries.size() >= 3) {
+        while (queries.size() >= 10) {
             queries.remove(queries.size() - 1);
         }
 


### PR DESCRIPTION
Still a WIP, but an attempt to fix bug 1030896. I stole the swipe listener logic from TabsTray, but removed some things we didn't need. I also updated it to use NOA, which led me to some problems trying to animate the height of the rows. It still doesn't work right... it looks like everything is working correctly, but then after the animation finishes an empty space pops back up in the list. Maybe the problem has to do with the cursor/adapter not actually being updated properly.

I also updated MockHistoryProvider to support deleting items, and to show more items in the list.
