### PR TITLE
Bug 1055315 - Add telemetry probe when changing default search service; 

### DIFF
--- a/app/src/main/java/org/mozilla/gecko/TelemetryContract.java
+++ b/app/src/main/java/org/mozilla/gecko/TelemetryContract.java
@@ -65,6 +65,15 @@ public interface TelemetryContract {
         // Perform a search -- currently used when starting a search in the search activity.
         SEARCH("search.1"),
 
+        // Remove a search engine.
+        SEARCH_REMOVE("search.remove.1"),
+
+        // Restore default search engines.
+        SEARCH_RESTORE_DEFAULTS("search.restoredefaults.1"),
+
+        // Set default search engine.
+        SEARCH_SET_DEFAULT("search.setdefault.1"),
+
         // Sharing content.
         SHARE("share.1"),
 
@@ -82,7 +91,8 @@ public interface TelemetryContract {
         _TEST1("_test_event_1.1"),
         _TEST2("_test_event_2.1"),
         _TEST3("_test_event_3.1"),
-        _TEST4("_test_event_4.1");
+        _TEST4("_test_event_4.1"),
+        ;
 
         private final String string;
 

--- a/app/src/main/java/org/mozilla/search/SearchPreferenceActivity.java
+++ b/app/src/main/java/org/mozilla/search/SearchPreferenceActivity.java
@@ -136,6 +136,9 @@ public class SearchPreferenceActivity extends PreferenceActivity
         if (TextUtils.equals(PREF_SEARCH_ENGINE_KEY, key)) {
             final ListPreference searchEnginePref = (ListPreference) findPreference(PREF_SEARCH_ENGINE_KEY);
             searchEnginePref.setSummary(searchEnginePref.getEntry());
+            Telemetry.sendUIEvent(TelemetryContract.Event.SEARCH_SET_DEFAULT,
+                                  TelemetryContract.Method.DIALOG,
+                                  searchEnginePref.getValue().toLowerCase());
         }
     }
 }


### PR DESCRIPTION
For bug 1055315 (https://bugzilla.mozilla.org/show_bug.cgi?id=1055315) in bugzilla.
