### PR TITLE
Bug 1060496 - Make search activity locale-aware

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -125,8 +125,10 @@ module.exports = function (grunt) {
                     exclude: [
                         "*AppConstants.java",
                         "*BrowserContract.java",
+                        "*BrowserLocaleManager.java",
                         "*GeckoJarReader.java",
                         "*GeckoSharedPrefs.java",
+                        "*LocaleManager.java",
                         "*MockHistoryProvider.java",
                         "*SuggestClient.java",
                         "*Telemetry.java",

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -128,6 +128,7 @@ module.exports = function (grunt) {
                         "*BrowserLocaleManager.java",
                         "*GeckoJarReader.java",
                         "*GeckoSharedPrefs.java",
+                        "*LocaleAware.java",
                         "*LocaleManager.java",
                         "*MockHistoryProvider.java",
                         "*SuggestClient.java",

--- a/app/src/main/java/org/mozilla/gecko/BrowserLocaleManager.java
+++ b/app/src/main/java/org/mozilla/gecko/BrowserLocaleManager.java
@@ -1,0 +1,80 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.gecko;
+
+import java.util.Locale;
+
+import android.content.Context;
+import android.content.res.Configuration;
+import android.content.res.Resources;
+import android.util.Log;
+
+/**
+ * This is a stub implementation to allow use in fennec-search.
+ */
+public class BrowserLocaleManager implements LocaleManager {
+    private static final String LOG_TAG = "BrowserLocaleManager";
+
+    @Override
+    public void initialize(Context context) {
+      Log.d(LOG_TAG, "Stub: initialize.");
+    }
+
+    @Override
+    public String getAndApplyPersistedLocale(Context context) {
+      Log.d(LOG_TAG, "Stub: getAndApplyPersistedLocale.");
+      return Locale.getDefault().toString();
+    }
+
+    @Override
+    public void correctLocale(Context context, Resources resources,
+                              Configuration newConfig) {
+      Log.d(LOG_TAG, "Stub: correctLocale.");
+    }
+
+    @Override
+    public String setSelectedLocale(Context context, String localeCode) {
+      Log.d(LOG_TAG, "Stub: setSelectedLocale: " + localeCode + ".");
+      return Locale.getDefault().toString();
+    }
+
+    @Override
+    public boolean systemLocaleDidChange() {
+      Log.d(LOG_TAG, "Stub: systemLocaleDidChange.");
+      return false;
+    }
+
+    public static LocaleManager getInstance() {
+      return new BrowserLocaleManager();
+    }
+
+    @Override
+    public void updateConfiguration(Context context, Locale locale) {
+    }
+
+    @Override
+    public Locale getCurrentLocale(Context context) {
+      Log.d(LOG_TAG, "Stub: getCurrentLocale.");
+      return Locale.getDefault();
+    }
+
+    @Override
+    public void resetToSystemLocale(Context context) {
+      Log.d(LOG_TAG, "Stub: resetToSystemLocale.");
+    }
+
+    @Override
+    public Locale onSystemConfigurationChanged(Context context,
+                                              Resources resources,
+                                              Configuration configuration,
+                                              Locale currentActivityLocale) {
+      return null;
+    }
+
+    @Override
+    public boolean isEnabled() {
+      return false;
+    }
+}

--- a/app/src/main/java/org/mozilla/gecko/LocaleAware.java
+++ b/app/src/main/java/org/mozilla/gecko/LocaleAware.java
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.gecko;
+
+import org.mozilla.gecko.BrowserLocaleManager;
+import org.mozilla.gecko.LocaleManager;
+
+import android.app.Activity;
+import android.content.Context;
+import android.os.Bundle;
+import android.os.StrictMode;
+import android.support.v4.app.FragmentActivity;
+
+/**
+ * This is a helper class to do typical locale switching operations
+ * without hitting StrictMode errors or adding boilerplate to common
+ * activity subclasses.
+ *
+ * Either call {@link LocaleAware#initializeLocale(Context)} in your
+ * <code>onCreate</code> method, or inherit from <code>LocaleAwareFragmentActivity</code>
+ * or <code>LocaleAwareActivity</code>.
+ */
+public class LocaleAware {
+  public static void initializeLocale(Context context) {
+    final LocaleManager localeManager = BrowserLocaleManager.getInstance();
+    final StrictMode.ThreadPolicy savedPolicy = StrictMode.allowThreadDiskReads();
+    StrictMode.allowThreadDiskWrites();
+    try {
+      localeManager.getAndApplyPersistedLocale(context);
+    } finally {
+      StrictMode.setThreadPolicy(savedPolicy);
+    }
+  }
+
+  public static class LocaleAwareFragmentActivity extends FragmentActivity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+      LocaleAware.initializeLocale(getApplicationContext());
+      super.onCreate(savedInstanceState);
+    }
+  }
+
+  public static class LocaleAwareActivity extends Activity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+      LocaleAware.initializeLocale(getApplicationContext());
+      super.onCreate(savedInstanceState);
+    }
+  }
+}

--- a/app/src/main/java/org/mozilla/gecko/LocaleManager.java
+++ b/app/src/main/java/org/mozilla/gecko/LocaleManager.java
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.gecko;
+
+import java.util.Locale;
+
+import android.content.Context;
+import android.content.res.Configuration;
+import android.content.res.Resources;
+
+/**
+ * Implement this interface to provide Fennec's locale switching functionality.
+ *
+ * The LocaleManager is responsible for persisting and applying selected locales,
+ * and correcting configurations after Android has changed them.
+ */
+public interface LocaleManager {
+    void initialize(Context context);
+
+    /**
+     * @return true if locale switching is enabled.
+     */
+    boolean isEnabled();
+    Locale getCurrentLocale(Context context);
+    String getAndApplyPersistedLocale(Context context);
+    void correctLocale(Context context, Resources resources, Configuration newConfig);
+    void updateConfiguration(Context context, Locale locale);
+    String setSelectedLocale(Context context, String localeCode);
+    boolean systemLocaleDidChange();
+    void resetToSystemLocale(Context context);
+
+    /**
+     * Call this in your onConfigurationChanged handler. This method is expected
+     * to do the appropriate thing: if the user has selected a locale, it
+     * corrects the incoming configuration; if not, it signals the new locale to
+     * use.
+     */
+    Locale onSystemConfigurationChanged(Context context, Resources resources, Configuration configuration, Locale currentActivityLocale);
+}

--- a/app/src/main/java/org/mozilla/search/MainActivity.java
+++ b/app/src/main/java/org/mozilla/search/MainActivity.java
@@ -20,6 +20,7 @@ import com.nineoldandroids.animation.Animator;
 import com.nineoldandroids.animation.AnimatorSet;
 import com.nineoldandroids.animation.ObjectAnimator;
 
+import org.mozilla.gecko.LocaleAware;
 import org.mozilla.gecko.Telemetry;
 import org.mozilla.gecko.TelemetryContract;
 import org.mozilla.gecko.db.BrowserContract.SearchHistory;
@@ -32,7 +33,7 @@ import org.mozilla.search.autocomplete.SuggestionsFragment;
  * State management is delegated to child fragments. Fragments communicate
  * with each other by passing messages through this activity.
  */
-public class MainActivity extends FragmentActivity implements AcceptsSearchQuery {
+public class MainActivity extends LocaleAware.LocaleAwareFragmentActivity implements AcceptsSearchQuery {
 
     private static final String KEY_SEARCH_STATE = "search_state";
     private static final String KEY_EDIT_STATE = "edit_state";

--- a/app/src/main/java/org/mozilla/search/SearchPreferenceActivity.java
+++ b/app/src/main/java/org/mozilla/search/SearchPreferenceActivity.java
@@ -18,6 +18,7 @@ import android.util.Log;
 import android.widget.Toast;
 
 import org.mozilla.gecko.GeckoSharedPrefs;
+import org.mozilla.gecko.LocaleAware;
 import org.mozilla.gecko.Telemetry;
 import org.mozilla.gecko.TelemetryContract;
 import org.mozilla.gecko.db.BrowserContract;
@@ -49,6 +50,7 @@ public class SearchPreferenceActivity extends PreferenceActivity
     @Override
     @SuppressWarnings("deprecation")
     protected void onCreate(Bundle savedInstanceState) {
+        LocaleAware.initializeLocale(getApplicationContext());
         super.onCreate(savedInstanceState);
 
         getPreferenceManager().setSharedPreferencesName(GeckoSharedPrefs.APP_PREFS_NAME);


### PR DESCRIPTION
We do this by importing `LocaleManager` and friends from Fennec, with a stub for use in the standalone activity, and invoking the right hooks.

Note that `LocaleAware` from Fennec is used, to avoid accruing duplicate boilerplate.
