### PR TITLE
Bug 1067026 - Fall back to en-US if search plugins aren't found for the ...

### DIFF
--- a/app/src/main/java/org/mozilla/search/providers/SearchEngineManager.java
+++ b/app/src/main/java/org/mozilla/search/providers/SearchEngineManager.java
@@ -233,19 +233,23 @@ public class SearchEngineManager implements SharedPreferences.OnSharedPreference
         final String languageTag = BrowserLocaleManager.getLanguageTag(locale);
         String url = getSearchPluginsJarURL(languageTag, fileName);
 
-        final InputStream in = GeckoJarReader.getStream(url);
+        InputStream in = GeckoJarReader.getStream(url);
         if (in != null) {
             return in;
         }
 
         // If that doesn't work, try a file path for just the language.
         final String language = BrowserLocaleManager.getLanguage(locale);
-        if (languageTag.equals(language)) {
-            // We already tried this, so just return null.
-            return null;
+        if (!languageTag.equals(language)) {
+            url = getSearchPluginsJarURL(language, fileName);
+            in = GeckoJarReader.getStream(url);
+            if (in != null) {
+                return in;
+            }
         }
 
-        url = getSearchPluginsJarURL(language, fileName);
+        // Finally, fall back to en-US.
+        url = getSearchPluginsJarURL("en-US", fileName);
         return GeckoJarReader.getStream(url);
     }
 


### PR DESCRIPTION
...user's locale. r=rnewman
